### PR TITLE
Skip chat event handling if event was cancelled

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "com.dumbdogdiner.stickychat"
-    version = "3.0.3-hotfix"
+    version = "3.0.4-hotfix"
 
     repositories {
         jcenter()

--- a/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/DeathListener.kt
+++ b/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/DeathListener.kt
@@ -8,6 +8,7 @@ import com.dumbdogdiner.stickychat.bukkit.WithPlugin
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.entity.PlayerDeathEvent
@@ -16,8 +17,12 @@ import org.bukkit.event.entity.PlayerDeathEvent
  * Listens for player deaths and calls the DeathMessage API.
  */
 class DeathListener : WithPlugin, Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     fun onPlayerDeath(e: PlayerDeathEvent) {
+        if (e.isCancelled) {
+            return
+        }
+
         val cause = e.entity.lastDamageCause
         if (cause == null) {
             this.logger.warning("Player ${e.entity.name} (${e.entity.uniqueId}) died without having a damage cause - cannot send death message")

--- a/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
+++ b/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
@@ -9,6 +9,9 @@ import org.bukkit.event.player.AsyncPlayerChatEvent
 class MessageListener : WithPlugin, Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onAsyncPlayerChatEvent(ev: AsyncPlayerChatEvent) {
+        // don't do this if another plugin cancelled this event already
+        if (ev.isCancelled) return
+
         ev.isCancelled = true
 
         // send staff chat if they have it enabled.

--- a/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
+++ b/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
@@ -10,7 +10,9 @@ class MessageListener : WithPlugin, Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     fun onAsyncPlayerChatEvent(ev: AsyncPlayerChatEvent) {
         // don't do this if another plugin cancelled this event already
-        if (ev.isCancelled) { return }
+        if (ev.isCancelled) {
+            return
+        }
 
         ev.isCancelled = true
 

--- a/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
+++ b/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/MessageListener.kt
@@ -7,10 +7,10 @@ import org.bukkit.event.Listener
 import org.bukkit.event.player.AsyncPlayerChatEvent
 
 class MessageListener : WithPlugin, Listener {
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.MONITOR)
     fun onAsyncPlayerChatEvent(ev: AsyncPlayerChatEvent) {
         // don't do this if another plugin cancelled this event already
-        if (ev.isCancelled) return
+        if (ev.isCancelled) { return }
 
         ev.isCancelled = true
 

--- a/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/PlayerJoinQuitListener.kt
+++ b/bukkit/src/main/kotlin/com/dumbdogdiner/stickychat/bukkit/listeners/PlayerJoinQuitListener.kt
@@ -2,6 +2,7 @@ package com.dumbdogdiner.stickychat.bukkit.listeners
 
 import com.dumbdogdiner.stickychat.bukkit.WithPlugin
 import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
@@ -10,7 +11,7 @@ import org.bukkit.event.player.PlayerQuitEvent
  * Listens for player joins and caches appropriate values. Forgets them when they leave.
  */
 class PlayerJoinQuitListener : WithPlugin, Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     fun onPlayerJoin(e: PlayerJoinEvent) {
         this.plugin.getNicknameService(e.player).loadNickname()
         // disable message hotfix
@@ -19,7 +20,7 @@ class PlayerJoinQuitListener : WithPlugin, Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     fun onPlayerLeave(e: PlayerQuitEvent) {
         logger.info("Saving settings for ${e.player} (${e.player.uniqueId})...")
         // disable message hotfix


### PR DESCRIPTION
If another plugin cancels a chat event, this fix now makes the chat event listener respect that setting and disregard the message.